### PR TITLE
Add supported Android builder releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,7 @@ body:
         - Mac with Apple Silicon
         - Intel Mac
         - Linux
+        - Android
         - Other
     validations:
       required: true

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -36,7 +36,7 @@ jobs:
           targets: aarch64-linux-android,x86_64-linux-android
       - name: Install pinned Android toolchain
         run: |
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
+          sdkmanager "platforms;android-35" "build-tools;36.0.0" "ndk;28.2.13676358"
           cargo install cargo-ndk --version 4.1.2 --locked
       - name: Build shared Rust engine for Android
         working-directory: patcher
@@ -62,7 +62,7 @@ jobs:
           gradle -p android --no-daemon :app:assembleRelease
           cp android/app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
           python3 packaging/audit_android_package.py "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
-          apksigner verify --verbose --print-certs "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
       - uses: actions/upload-artifact@v4
         with:
           name: MariosMaskBuilder-android.apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,77 @@
+name: android-builder-package
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing GitHub release tag to receive the APK
+        required: true
+        default: v0.9.0
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Match source version to requested release
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: test "v$(cat VERSION)" = "$RELEASE_TAG"
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "9.5.0"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+      - name: Install pinned Android toolchain
+        run: |
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
+          cargo install cargo-ndk --version 4.1.2 --locked
+      - name: Build shared Rust engine for Android
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+        run: |
+          cargo ndk -t arm64-v8a -t x86_64 -o android/app/src/main/jniLibs \
+            build --release --manifest-path patcher/Cargo.toml --locked \
+            --no-default-features --features android-jni
+      - name: Restore Android release signing key
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64"
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/marios-mask-release.jks"
+      - name: Build and audit signed APK
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/marios-mask-release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          gradle -p android --no-daemon :app:assembleRelease
+          cp android/app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
+          python3 packaging/audit_android_package.py "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
+          apksigner verify --verbose --print-certs "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: MariosMaskBuilder-android.apk
+          path: ${{ runner.temp }}/MariosMaskBuilder-android.apk
+          if-no-files-found: error
+      - name: Add APK to existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          gh release view "$RELEASE_TAG"
+          gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/MariosMaskBuilder-android.apk" --clobber

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -39,11 +39,12 @@ jobs:
           sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
           cargo install cargo-ndk --version 4.1.2 --locked
       - name: Build shared Rust engine for Android
+        working-directory: patcher
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
         run: |
-          cargo ndk -t arm64-v8a -t x86_64 -o android/app/src/main/jniLibs \
-            build --release --manifest-path patcher/Cargo.toml --locked \
+          cargo ndk -t arm64-v8a -t x86_64 -o ../android/app/src/main/jniLibs \
+            build --release --locked \
             --no-default-features --features android-jni
       - name: Restore Android release signing key
         env:

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -13,6 +13,56 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  android-package:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "9.5.0"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+      - name: Install pinned Android toolchain
+        run: |
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
+          cargo install cargo-ndk --version 4.1.2 --locked
+      - name: Build shared Rust engine for Android
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+        run: |
+          cargo ndk -t arm64-v8a -t x86_64 -o android/app/src/main/jniLibs \
+            build --release --manifest-path patcher/Cargo.toml --locked \
+            --no-default-features --features android-jni
+      - name: Restore Android release signing key
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64"
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/marios-mask-release.jks"
+      - name: Build and audit signed APK
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/marios-mask-release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          gradle -p android --no-daemon :app:assembleRelease
+          mkdir -p "$RUNNER_TEMP/release"
+          cp android/app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
+          python3 packaging/audit_android_package.py "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
+          apksigner verify --verbose --print-certs "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: MariosMaskBuilder-android.apk
+          path: ${{ runner.temp }}/release/MariosMaskBuilder-android.apk
+          if-no-files-found: error
+
   posix-packages:
     strategy:
       fail-fast: false
@@ -99,7 +149,7 @@ jobs:
 
   publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [posix-packages, windows-package]
+    needs: [android-package, posix-packages, windows-package]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -33,11 +33,12 @@ jobs:
           sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
           cargo install cargo-ndk --version 4.1.2 --locked
       - name: Build shared Rust engine for Android
+        working-directory: patcher
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
         run: |
-          cargo ndk -t arm64-v8a -t x86_64 -o android/app/src/main/jniLibs \
-            build --release --manifest-path patcher/Cargo.toml --locked \
+          cargo ndk -t arm64-v8a -t x86_64 -o ../android/app/src/main/jniLibs \
+            build --release --locked \
             --no-default-features --features android-jni
       - name: Restore Android release signing key
         env:

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -30,7 +30,7 @@ jobs:
           targets: aarch64-linux-android,x86_64-linux-android
       - name: Install pinned Android toolchain
         run: |
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
+          sdkmanager "platforms;android-35" "build-tools;36.0.0" "ndk;28.2.13676358"
           cargo install cargo-ndk --version 4.1.2 --locked
       - name: Build shared Rust engine for Android
         working-directory: patcher
@@ -57,7 +57,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/release"
           cp android/app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
           python3 packaging/audit_android_package.py "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
-          apksigner verify --verbose --print-certs "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
       - uses: actions/upload-artifact@v4
         with:
           name: MariosMaskBuilder-android.apk

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -25,11 +25,12 @@ jobs:
           sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
           cargo install cargo-ndk --version 4.1.2 --locked
       - name: Build Android JNI libraries
+        working-directory: patcher
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
         run: |
-          cargo ndk -t arm64-v8a -t x86_64 -o android/app/src/main/jniLibs \
-            build --release --manifest-path patcher/Cargo.toml --locked \
+          cargo ndk -t arm64-v8a -t x86_64 -o ../android/app/src/main/jniLibs \
+            build --release --locked \
             --no-default-features --features android-jni
       - name: Build and audit debug-signed APK
         run: |

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -5,6 +5,38 @@ on:
   pull_request:
 
 jobs:
+  android-release-source:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "9.5.0"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+      - name: Install pinned Android toolchain
+        run: |
+          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
+          cargo install cargo-ndk --version 4.1.2 --locked
+      - name: Build Android JNI libraries
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
+        run: |
+          cargo ndk -t arm64-v8a -t x86_64 -o android/app/src/main/jniLibs \
+            build --release --manifest-path patcher/Cargo.toml --locked \
+            --no-default-features --features android-jni
+      - name: Build and audit debug-signed APK
+        run: |
+          gradle -p android --no-daemon :app:assembleDebug
+          python3 packaging/audit_android_package.py android/app/build/outputs/apk/debug/app-debug.apk
+          apksigner verify --verbose android/app/build/outputs/apk/debug/app-debug.apk
+
   standalone-release:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -22,7 +22,7 @@ jobs:
           targets: aarch64-linux-android,x86_64-linux-android
       - name: Install pinned Android toolchain
         run: |
-          sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;28.2.13676358"
+          sdkmanager "platforms;android-35" "build-tools;36.0.0" "ndk;28.2.13676358"
           cargo install cargo-ndk --version 4.1.2 --locked
       - name: Build Android JNI libraries
         working-directory: patcher
@@ -36,7 +36,7 @@ jobs:
         run: |
           gradle -p android --no-daemon :app:assembleDebug
           python3 packaging/audit_android_package.py android/app/build/outputs/apk/debug/app-debug.apk
-          apksigner verify --verbose android/app/build/outputs/apk/debug/app-debug.apk
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose android/app/build/outputs/apk/debug/app-debug.apk
 
   standalone-release:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ __pycache__/
 *.v64
 *.z64
 patcher/target/
+android/.gradle/
+android/local.properties
+android/**/build/
+android/app/src/main/jniLibs/
+*.apk
+*.aab
+*.jks
+*.keystore
 # optional headless-test plugins, always built locally from tools/inputbot/*.c
 tools/inputbot/*.dylib
 tools/inputbot/*.so

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Bring your own USA Nintendo 64 versions of *Super Mario 64* and *Majora's Mask*.
 The builder combines them locally on your computer.
 
 1. [Open the latest release](https://github.com/msmfai/marios-mask/releases/latest).
-2. Under **Assets**, download **MariosMaskBuilder** for Windows, macOS, or Linux.
+2. Under **Assets**, download **MariosMaskBuilder** for Windows, macOS, Linux,
+   or Android.
 3. Extract it and open **MariosMaskBuilder**.
 4. Choose both game files and where to save the result.
 5. Click **Build Mario's Mask**.
@@ -135,6 +136,9 @@ Raw `.z64`, `.v64`, and `.n64` files work, as do `.zip` and `.gz` archives.
 
 Having trouble opening the builder?
 
+- **Android:** Download `MariosMaskBuilder-android.apk`, allow installation from
+  your browser or file manager when Android asks, then open **Mario's Mask
+  Builder**. Android 8.0 or newer on a 64-bit device is required.
 - **Mac:** Control-click it, choose **Open**, then choose **Open** again.
 - **Windows:** Choose **More info**, then **Run anyway** if SmartScreen appears.
 - **Linux:** Extract the whole archive before opening it.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,8 +44,9 @@ Majora's Mask's world, enemies, and scripted scenes.
 | Mac with Apple Silicon (M1 or newer) | `MariosMaskBuilder-macos-apple-silicon.zip` |
 | Mac with an Intel processor | `MariosMaskBuilder-macos-intel.zip` |
 | 64-bit Linux | `MariosMaskBuilder-linux-x86_64.tar.gz` |
+| Android 8.0 or newer, 64-bit | `MariosMaskBuilder-android.apk` |
 
-Choose one of the four **MariosMaskBuilder** files under **Assets**.
+Choose the **MariosMaskBuilder** file for your platform under **Assets**.
 
 ## Build Mario's Mask
 
@@ -56,3 +57,6 @@ Choose one of the four **MariosMaskBuilder** files under **Assets**.
 5. Open `Marios-Mask.z64` in an N64 emulator or flash cart.
 
 The builder combines your two game files locally on your computer.
+On Android, install the APK, choose both ROMs through Android's document picker,
+and save the finished ROM directly to your device. The app requests no network
+or broad storage permission.

--- a/android/README.md
+++ b/android/README.md
@@ -14,10 +14,11 @@ The generated JNI libraries and APK are build products and must not be committed
 Build the Rust engine before invoking Gradle:
 
 ```sh
+cd patcher
 cargo ndk -t arm64-v8a -t x86_64 \
-  -o android/app/src/main/jniLibs \
-  build --release --manifest-path patcher/Cargo.toml --locked \
-  --no-default-features --features android-jni
+  -o ../android/app/src/main/jniLibs \
+  build --release --locked --no-default-features --features android-jni
+cd ..
 gradle -p android :app:assembleDebug
 ```
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,26 @@
+# Android builder
+
+The Android app is a thin Storage Access Framework UI over the same Rust recipe
+engine used by the desktop builder. It requests no broad storage permission and
+no network permission. Both source ROMs are copied into the app's private cache,
+validated and combined locally, then removed after the selected output document
+has been written.
+
+Supported release ABIs are `arm64-v8a` for physical 64-bit Android devices and
+`x86_64` for Android emulators. The minimum supported system is Android 8.0
+(API 26).
+
+The generated JNI libraries and APK are build products and must not be committed.
+Build the Rust engine before invoking Gradle:
+
+```sh
+cargo ndk -t arm64-v8a -t x86_64 \
+  -o android/app/src/main/jniLibs \
+  build --release --manifest-path patcher/Cargo.toml --locked \
+  --no-default-features --features android-jni
+gradle -p android :app:assembleDebug
+```
+
+Release builds require the four `ANDROID_KEY*`/`ANDROID_KEYSTORE*` environment
+variables enforced by `android/app/build.gradle`. GitHub Actions owns release
+signing and publishes `MariosMaskBuilder-android.apk`.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,80 @@
+plugins {
+    id "com.android.application"
+}
+
+def releaseVersion = rootProject.file("../VERSION").text.trim()
+def releaseKeystore = System.getenv("ANDROID_KEYSTORE_PATH")
+
+android {
+    namespace "ai.smf.mariosmask"
+    compileSdk 35
+    buildToolsVersion "35.0.0"
+
+    defaultConfig {
+        applicationId "ai.smf.mariosmask.builder"
+        minSdk 26
+        targetSdk 35
+        versionCode 900
+        versionName releaseVersion
+
+        ndk {
+            abiFilters "arm64-v8a", "x86_64"
+        }
+    }
+
+    signingConfigs {
+        release {
+            if (releaseKeystore) {
+                storeFile file(releaseKeystore)
+                storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+            versionNameSuffix "-debug"
+        }
+        release {
+            minifyEnabled false
+            if (releaseKeystore) {
+                signingConfig signingConfigs.release
+            }
+        }
+    }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ["src/main/jniLibs"]
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+}
+
+tasks.register("requireReleaseSigning") {
+    doLast {
+        def required = [
+            "ANDROID_KEYSTORE_PATH",
+            "ANDROID_KEYSTORE_PASSWORD",
+            "ANDROID_KEY_ALIAS",
+            "ANDROID_KEY_PASSWORD",
+        ]
+        def missing = required.findAll { !System.getenv(it) }
+        if (!missing.isEmpty()) {
+            throw new GradleException("Missing Android release signing variables: " + missing.join(", "))
+        }
+    }
+}
+
+tasks.configureEach {
+    if (name == "assembleRelease") {
+        dependsOn("requireReleaseSigning")
+    }
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,6 @@ def releaseKeystore = System.getenv("ANDROID_KEYSTORE_PATH")
 android {
     namespace "ai.smf.mariosmask"
     compileSdk 35
-    buildToolsVersion "35.0.0"
 
     defaultConfig {
         applicationId "ai.smf.mariosmask.builder"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="false"
-        android:extractNativeLibs="false"
         android:label="Mario's Mask Builder"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="false"
+        android:extractNativeLibs="false"
+        android:label="Mario's Mask Builder"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:screenOrientation="unspecified">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/ai/smf/mariosmask/MainActivity.java
+++ b/android/app/src/main/java/ai/smf/mariosmask/MainActivity.java
@@ -1,0 +1,332 @@
+package ai.smf.mariosmask;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.database.Cursor;
+import android.graphics.Color;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.OpenableColumns;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public final class MainActivity extends Activity {
+    private static final int CHOOSE_SM64 = 100;
+    private static final int CHOOSE_MM = 101;
+    private static final int CHOOSE_OUTPUT = 102;
+    private static final long MAX_INPUT_BYTES = 128L * 1024L * 1024L;
+
+    static {
+        System.loadLibrary("marios_mask_builder");
+    }
+
+    private static native String nativeBuild(String sm64, String mm, String output);
+
+    private final ExecutorService builder = Executors.newSingleThreadExecutor();
+    private Uri sm64Uri;
+    private Uri mmUri;
+    private Button sm64Button;
+    private Button mmButton;
+    private Button buildButton;
+    private TextView statusView;
+
+    @Override
+    protected void onCreate(Bundle state) {
+        super.onCreate(state);
+        if (state != null) {
+            sm64Uri = parseUri(state.getString("sm64"));
+            mmUri = parseUri(state.getString("mm"));
+        }
+        setContentView(createContent());
+        refreshSelections();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle state) {
+        super.onSaveInstanceState(state);
+        state.putString("sm64", sm64Uri == null ? null : sm64Uri.toString());
+        state.putString("mm", mmUri == null ? null : mmUri.toString());
+    }
+
+    @Override
+    protected void onDestroy() {
+        builder.shutdown();
+        super.onDestroy();
+    }
+
+    private View createContent() {
+        int margin = dp(22);
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(margin, margin, margin, margin);
+
+        TextView title = text("Mario's Mask Builder", 28, Color.rgb(55, 36, 23));
+        title.setTypeface(title.getTypeface(), android.graphics.Typeface.BOLD);
+        content.addView(title);
+
+        TextView intro = text(
+            "Choose your own NTSC-US Super Mario 64 and Majora's Mask ROMs. " +
+                "They stay on this device and are combined locally.",
+            16,
+            Color.DKGRAY
+        );
+        intro.setPadding(0, dp(10), 0, dp(20));
+        content.addView(intro);
+
+        sm64Button = button("Choose Super Mario 64", view -> chooseRom(CHOOSE_SM64));
+        content.addView(sm64Button);
+        content.addView(spacer());
+
+        mmButton = button("Choose Majora's Mask", view -> chooseRom(CHOOSE_MM));
+        content.addView(mmButton);
+        content.addView(spacer());
+
+        buildButton = button("Build Mario's Mask", view -> chooseOutput());
+        content.addView(buildButton);
+
+        statusView = text("Choose both ROMs to begin.", 15, Color.DKGRAY);
+        statusView.setPadding(0, dp(18), 0, dp(8));
+        statusView.setGravity(Gravity.START);
+        statusView.setTextIsSelectable(true);
+        content.addView(statusView);
+
+        TextView formats = text(
+            "Accepted inputs: .z64, .v64, .n64, .rom, .zip, and .gz. " +
+                "The finished .z64 can be opened in an Android N64 emulator or copied to a flash cart.",
+            13,
+            Color.GRAY
+        );
+        formats.setPadding(0, dp(8), 0, 0);
+        content.addView(formats);
+
+        ScrollView scroll = new ScrollView(this);
+        scroll.addView(content);
+        return scroll;
+    }
+
+    private Button button(String label, View.OnClickListener listener) {
+        Button button = new Button(this);
+        button.setText(label);
+        button.setAllCaps(false);
+        button.setTextSize(16);
+        button.setMinHeight(dp(54));
+        button.setOnClickListener(listener);
+        return button;
+    }
+
+    private TextView text(String value, int size, int color) {
+        TextView view = new TextView(this);
+        view.setText(value);
+        view.setTextSize(size);
+        view.setTextColor(color);
+        view.setLineSpacing(0, 1.12f);
+        return view;
+    }
+
+    private View spacer() {
+        View view = new View(this);
+        view.setLayoutParams(new LinearLayout.LayoutParams(1, dp(10)));
+        return view;
+    }
+
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
+    }
+
+    private void chooseRom(int requestCode) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+        startActivityForResult(intent, requestCode);
+    }
+
+    private void chooseOutput() {
+        if (sm64Uri == null || mmUri == null) {
+            setStatus("Choose both ROMs first.", true);
+            return;
+        }
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("application/octet-stream");
+        intent.putExtra(Intent.EXTRA_TITLE, "Marios-Mask.z64");
+        intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        startActivityForResult(intent, CHOOSE_OUTPUT);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode != RESULT_OK || data == null || data.getData() == null) {
+            return;
+        }
+        Uri uri = data.getData();
+        if (requestCode == CHOOSE_SM64 || requestCode == CHOOSE_MM) {
+            persistReadPermission(uri, data.getFlags());
+            if (requestCode == CHOOSE_SM64) {
+                sm64Uri = uri;
+            } else {
+                mmUri = uri;
+            }
+            refreshSelections();
+        } else if (requestCode == CHOOSE_OUTPUT) {
+            startBuild(uri);
+        }
+    }
+
+    private void persistReadPermission(Uri uri, int flags) {
+        int granted = flags & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        try {
+            getContentResolver().takePersistableUriPermission(uri, granted);
+        } catch (SecurityException ignored) {
+            // Some document providers grant access for the Activity lifetime only.
+        }
+    }
+
+    private void refreshSelections() {
+        if (sm64Button == null) {
+            return;
+        }
+        sm64Button.setText(sm64Uri == null ? "Choose Super Mario 64" : "Super Mario 64: " + displayName(sm64Uri));
+        mmButton.setText(mmUri == null ? "Choose Majora's Mask" : "Majora's Mask: " + displayName(mmUri));
+        buildButton.setEnabled(sm64Uri != null && mmUri != null);
+        if (sm64Uri != null && mmUri != null) {
+            setStatus("Ready. Choose where to save the finished game.", false);
+        }
+    }
+
+    private String displayName(Uri uri) {
+        try (Cursor cursor = getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                int column = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (column >= 0) {
+                    return cursor.getString(column);
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Fall back to the final URI path segment.
+        }
+        String segment = uri.getLastPathSegment();
+        return segment == null ? "selected file" : segment;
+    }
+
+    private void startBuild(Uri outputUri) {
+        setBuilding(true);
+        setStatus("Reading and validating both ROMs…", false);
+        builder.execute(() -> {
+            File work = new File(getCacheDir(), "build-" + System.nanoTime());
+            try {
+                if (!work.mkdirs()) {
+                    throw new IOException("Could not create temporary build storage.");
+                }
+                File sm64 = new File(work, "sm64.input");
+                File mm = new File(work, "mm.input");
+                File output = new File(work, "Marios-Mask.z64");
+                copyInput(sm64Uri, sm64);
+                copyInput(mmUri, mm);
+
+                runOnUiThread(() -> setStatus("Building Mario's Mask locally…", false));
+                String error = nativeBuild(sm64.getAbsolutePath(), mm.getAbsolutePath(), output.getAbsolutePath());
+                if (error == null) {
+                    throw new IOException("The native builder could not return a result.");
+                }
+                if (!error.isEmpty()) {
+                    throw new IOException(error);
+                }
+                copyOutput(output, outputUri);
+                runOnUiThread(() -> {
+                    setStatus("Done! Open Marios-Mask.z64 in your N64 emulator.", false);
+                    Toast.makeText(this, "Mario's Mask was built successfully.", Toast.LENGTH_LONG).show();
+                });
+            } catch (Exception error) {
+                String message = error.getMessage();
+                if (message == null || message.isBlank()) {
+                    message = error.getClass().getSimpleName();
+                }
+                String finalMessage = message;
+                runOnUiThread(() -> setStatus(finalMessage, true));
+            } finally {
+                deleteRecursively(work);
+                runOnUiThread(() -> setBuilding(false));
+            }
+        });
+    }
+
+    private void copyInput(Uri source, File destination) throws IOException {
+        ContentResolver resolver = getContentResolver();
+        try (InputStream input = resolver.openInputStream(source);
+             OutputStream output = new FileOutputStream(destination)) {
+            if (input == null) {
+                throw new IOException("Could not open " + displayName(source) + ".");
+            }
+            copyLimited(input, output, MAX_INPUT_BYTES, "Input ROM exceeds 128 MiB.");
+        }
+    }
+
+    private void copyOutput(File source, Uri destination) throws IOException {
+        try (InputStream input = new java.io.FileInputStream(source);
+             OutputStream output = getContentResolver().openOutputStream(destination, "wt")) {
+            if (output == null) {
+                throw new IOException("Could not open the selected output file.");
+            }
+            copyLimited(input, output, MAX_INPUT_BYTES, "Finished ROM exceeds 128 MiB.");
+            output.flush();
+        }
+    }
+
+    private void copyLimited(InputStream input, OutputStream output, long limit, String message) throws IOException {
+        byte[] buffer = new byte[64 * 1024];
+        long total = 0;
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+            total += count;
+            if (total > limit) {
+                throw new IOException(message);
+            }
+            output.write(buffer, 0, count);
+        }
+    }
+
+    private void setBuilding(boolean active) {
+        sm64Button.setEnabled(!active);
+        mmButton.setEnabled(!active);
+        buildButton.setEnabled(!active && sm64Uri != null && mmUri != null);
+    }
+
+    private void setStatus(String message, boolean error) {
+        statusView.setText(message);
+        statusView.setTextColor(error ? Color.rgb(176, 0, 32) : Color.DKGRAY);
+    }
+
+    private static Uri parseUri(String value) {
+        return value == null || value.isBlank() ? null : Uri.parse(value);
+    }
+
+    private static void deleteRecursively(File path) {
+        if (path == null || !path.exists()) {
+            return;
+        }
+        File[] children = path.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        // Best effort: private cache data is also removed by Android eventually.
+        path.delete();
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.application" version "9.3.0" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+android.useAndroidX=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-android.useAndroidX=false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MariosMaskBuilder"
+include(":app")

--- a/packaging/audit_android_package.py
+++ b/packaging/audit_android_package.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Audit a release APK without unpacking or executing it."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+MAX_APK_BYTES = 30 * 1024 * 1024
+ALLOWED_ABIS = {"arm64-v8a", "x86_64"}
+LIBRARY = "libmarios_mask_builder.so"
+FORBIDDEN_SUFFIXES = {".z64", ".v64", ".n64", ".rom", ".sav", ".sra"}
+N64_MAGICS = {
+    bytes.fromhex("80371240"),
+    bytes.fromhex("37804012"),
+    bytes.fromhex("40123780"),
+}
+
+
+def audit(apk: Path) -> list[str]:
+    failures: list[str] = []
+    if not apk.is_file():
+        return [f"APK is missing: {apk}"]
+    if apk.suffix.lower() != ".apk":
+        failures.append("release asset does not use the .apk extension")
+    if apk.stat().st_size > MAX_APK_BYTES:
+        failures.append(f"APK exceeds {MAX_APK_BYTES} bytes")
+
+    try:
+        with zipfile.ZipFile(apk) as archive:
+            names = set(archive.namelist())
+            for required in {"AndroidManifest.xml", "classes.dex"}:
+                if required not in names:
+                    failures.append(f"APK is missing {required}")
+
+            expected_libraries = {f"lib/{abi}/{LIBRARY}" for abi in ALLOWED_ABIS}
+            for missing in sorted(expected_libraries - names):
+                failures.append(f"APK is missing {missing}")
+
+            observed_abis: set[str] = set()
+            for info in archive.infolist():
+                path = PurePosixPath(info.filename)
+                if path.is_absolute() or ".." in path.parts:
+                    failures.append(f"unsafe APK path: {info.filename}")
+                    continue
+                if path.suffix.lower() in FORBIDDEN_SUFFIXES:
+                    failures.append(f"forbidden ROM/save file in APK: {info.filename}")
+                if len(path.parts) >= 3 and path.parts[0] == "lib":
+                    observed_abis.add(path.parts[1])
+                    if path.name != LIBRARY:
+                        failures.append(f"unexpected native library: {info.filename}")
+                if not info.is_dir():
+                    with archive.open(info) as handle:
+                        if handle.read(4) in N64_MAGICS:
+                            failures.append(f"N64 ROM header in APK: {info.filename}")
+
+            if observed_abis != ALLOWED_ABIS:
+                failures.append(
+                    f"APK ABIs are {sorted(observed_abis)}, expected {sorted(ALLOWED_ABIS)}"
+                )
+    except (OSError, zipfile.BadZipFile) as error:
+        failures.append(f"invalid APK/ZIP: {error}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("apk", type=Path)
+    args = parser.parse_args()
+    failures = audit(args.apk)
+    if failures:
+        print("Android package audit failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("Android package audit passed: expected 64-bit ABIs; no ROMs or saves")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/patcher/Cargo.lock
+++ b/patcher/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "android-properties",
  "bitflags 2.13.1",
  "cc",
- "jni",
+ "jni 0.22.4",
  "libc",
  "log",
  "ndk",
@@ -477,6 +477,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1428,6 +1434,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -1605,6 +1627,7 @@ dependencies = [
  "anyhow",
  "eframe",
  "flate2",
+ "jni 0.21.1",
  "rfd",
  "sha1",
  "sha2",
@@ -3186,7 +3209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
- "jni",
+ "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
@@ -3407,6 +3430,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3439,6 +3471,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3476,6 +3523,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3488,6 +3541,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3497,6 +3556,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3524,6 +3589,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3533,6 +3604,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3548,6 +3625,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3557,6 +3640,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/patcher/Cargo.toml
+++ b/patcher/Cargo.toml
@@ -5,22 +5,31 @@ edition = "2021"
 license = "GPL-3.0-only"
 description = "Standalone two-ROM builder for Mario's Mask"
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [features]
-default = []
+default = ["desktop"]
+desktop = ["dep:eframe", "dep:rfd"]
+android-jni = ["dep:jni"]
 recipe-tool = []
 
 [dependencies]
 anyhow = "1.0"
-eframe = { version = "0.31.1", default-features = false, features = ["default_fonts", "glow", "x11"] }
+eframe = { version = "0.31.1", default-features = false, features = ["default_fonts", "glow", "x11"], optional = true }
 flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }
-rfd = { version = "0.15.4", default-features = false, features = ["async-std", "xdg-portal"] }
+rfd = { version = "0.15.4", default-features = false, features = ["async-std", "xdg-portal"], optional = true }
 sha1 = "0.10"
 sha2 = "0.10"
 zip = { version = "2.4", default-features = false, features = ["deflate"] }
 
+[target.'cfg(target_os = "android")'.dependencies]
+jni = { version = "0.21.1", optional = true }
+
 [[bin]]
 name = "marios-mask-builder"
 path = "src/main.rs"
+required-features = ["desktop"]
 
 [[bin]]
 name = "marios-mask-recipe"

--- a/patcher/src/android.rs
+++ b/patcher/src/android.rs
@@ -1,0 +1,46 @@
+use jni::objects::{JClass, JString};
+use jni::sys::jstring;
+use jni::JNIEnv;
+use std::path::Path;
+use std::ptr;
+
+fn path_from_java(env: &mut JNIEnv<'_>, value: &JString<'_>) -> Result<String, String> {
+    env.get_string(value)
+        .map(|text| text.into())
+        .map_err(|error| format!("Could not read an Android file path: {error}"))
+}
+
+fn build(
+    env: &mut JNIEnv<'_>,
+    sm64: &JString<'_>,
+    mm: &JString<'_>,
+    output: &JString<'_>,
+) -> Result<(), String> {
+    let sm64 = path_from_java(env, sm64)?;
+    let mm = path_from_java(env, mm)?;
+    let output = path_from_java(env, output)?;
+    crate::build_from_paths(Path::new(&sm64), Path::new(&mm), Path::new(&output), |_| {})
+        .map_err(|error| format!("{error:#}"))
+}
+
+/// Returns an empty Java string on success and a user-facing error on failure.
+/// No panic or Rust-owned pointer crosses the JNI boundary.
+#[no_mangle]
+pub extern "system" fn Java_ai_smf_mariosmask_MainActivity_nativeBuild(
+    mut env: JNIEnv<'_>,
+    _class: JClass<'_>,
+    sm64: JString<'_>,
+    mm: JString<'_>,
+    output: JString<'_>,
+) -> jstring {
+    let message = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build(&mut env, &sm64, &mm, &output)
+    })) {
+        Ok(Ok(())) => String::new(),
+        Ok(Err(error)) => error,
+        Err(_) => "The native builder stopped unexpectedly.".to_owned(),
+    };
+    env.new_string(message)
+        .map(|text| text.into_raw())
+        .unwrap_or_else(|_| ptr::null_mut())
+}

--- a/patcher/src/lib.rs
+++ b/patcher/src/lib.rs
@@ -5,6 +5,9 @@ use std::fs;
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 
+#[cfg(all(target_os = "android", feature = "android-jni"))]
+mod android;
+
 pub mod recipe;
 
 const MAX_INPUT_SIZE: usize = 128 * 1024 * 1024;

--- a/site/app.js
+++ b/site/app.js
@@ -8,6 +8,7 @@ function preferredPlatform() {
   const platform = navigator.userAgentData?.platform || navigator.platform || "";
   const agent = navigator.userAgent || "";
 
+  if (/Android/i.test(agent)) return "android";
   if (/Win/i.test(platform) || /Windows/i.test(agent)) return "windows";
   if (/Linux/i.test(platform) || /Linux/i.test(agent)) return "linux";
   if (/Mac/i.test(platform) || /Macintosh/i.test(agent)) return "macAppleSilicon";
@@ -32,7 +33,13 @@ async function configureDownloads() {
     if (platform && stable.assets[platform]) {
       primary.href = releaseAssetUrl(stable, stable.assets[platform]);
       primary.textContent = `Download ${stable.version} for ${
-        platform === "windows" ? "Windows" : platform === "linux" ? "Linux" : "Mac"
+        platform === "windows"
+          ? "Windows"
+          : platform === "linux"
+            ? "Linux"
+            : platform === "android"
+              ? "Android"
+              : "Mac"
       }`;
     } else {
       primary.href = `https://github.com/${stable.repository}/releases/tag/${stable.tag}`;

--- a/site/index.html
+++ b/site/index.html
@@ -50,6 +50,7 @@
           <a data-platform="macAppleSilicon" href="https://github.com/msmfai/marios-mask/releases">Mac — Apple Silicon</a>
           <a data-platform="macIntel" href="https://github.com/msmfai/marios-mask/releases">Mac — Intel</a>
           <a data-platform="linux" href="https://github.com/msmfai/marios-mask/releases">Linux</a>
+          <a data-platform="android" href="https://github.com/msmfai/marios-mask/releases">Android</a>
         </div>
         <p class="build-note">
           Bring your own USA copies of <em>Super Mario 64</em> and

--- a/site/stable.json
+++ b/site/stable.json
@@ -6,6 +6,7 @@
     "windows": "MariosMaskBuilder-windows-x86_64.zip",
     "macAppleSilicon": "MariosMaskBuilder-macos-apple-silicon.zip",
     "macIntel": "MariosMaskBuilder-macos-intel.zip",
-    "linux": "MariosMaskBuilder-linux-x86_64.tar.gz"
+    "linux": "MariosMaskBuilder-linux-x86_64.tar.gz",
+    "android": "MariosMaskBuilder-android.apk"
   }
 }

--- a/tools/check_project_site.py
+++ b/tools/check_project_site.py
@@ -15,6 +15,7 @@ EXPECTED_ASSETS = {
     "macAppleSilicon": "MariosMaskBuilder-macos-apple-silicon.zip",
     "macIntel": "MariosMaskBuilder-macos-intel.zip",
     "linux": "MariosMaskBuilder-linux-x86_64.tar.gz",
+    "android": "MariosMaskBuilder-android.apk",
 }
 
 

--- a/tools/check_release_contract.py
+++ b/tools/check_release_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import plistlib
 import re
 from pathlib import Path
@@ -47,6 +48,17 @@ def main() -> int:
     notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
     report = (ROOT / "patcher/recipe/REPORT.md").read_text(encoding="utf-8")
     library = (ROOT / "patcher/src/lib.rs").read_text(encoding="utf-8")
+    android_build = (ROOT / "android/app/build.gradle").read_text(encoding="utf-8")
+    android_manifest = (ROOT / "android/app/src/main/AndroidManifest.xml").read_text(
+        encoding="utf-8"
+    )
+    release_workflow = (ROOT / ".github/workflows/binary-release.yml").read_text(
+        encoding="utf-8"
+    )
+    android_workflow = (ROOT / ".github/workflows/android-release.yml").read_text(
+        encoding="utf-8"
+    )
+    stable = json.loads((ROOT / "site/stable.json").read_text(encoding="utf-8"))
     with (ROOT / "packaging/macos/Info.plist").open("rb") as handle:
         macos = plistlib.load(handle)
     recipe = (ROOT / release_audit.RECIPE).read_bytes()
@@ -66,6 +78,20 @@ def main() -> int:
         notes.startswith(f"# Mario's Mask Alpha {version}\n"),
         "release notes title does not match VERSION",
     )
+    require(
+        'rootProject.file("../VERSION")' in android_build
+        and "versionName releaseVersion" in android_build,
+        "Android versionName is not derived from VERSION",
+    )
+    require(
+        "<uses-permission" not in android_manifest,
+        "Android builder must use the document picker without broad permissions",
+    )
+    android_asset = "MariosMaskBuilder-android.apk"
+    require(android_asset in notes, "release notes omit the Android APK")
+    require(android_asset in release_workflow, "tag workflow omits the Android APK")
+    require(android_asset in android_workflow, "Android workflow uses the wrong asset name")
+    require(stable["assets"].get("android") == android_asset, "site Android asset disagrees")
 
     digest = hashlib.sha256(recipe).hexdigest()
     require(

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -13,6 +13,7 @@ from pathlib import Path
 ALLOWED_TOP_LEVEL = {
     ".github",
     ".gitignore",
+    "android",
     "LICENSE",
     "PROVENANCE.md",
     "README.md",
@@ -36,6 +37,7 @@ FORBIDDEN_ROOTS = {
 RECIPE = "patcher/recipe/marios-mask.mmrecipe"
 EXPECTED_RECIPE_SHA256 = "05010e358dee5d91772ea042026315dcb4f1c9f4e71a51f58c6faa3f5445ff2d"
 REQUIRED = {
+    ".github/workflows/android-release.yml",
     ".github/workflows/binary-release.yml",
     ".github/workflows/project-pages.yml",
     ".github/workflows/release-audit.yml",
@@ -46,6 +48,7 @@ REQUIRED = {
     "RELEASE_NOTES.md",
     "VERSION",
     "packaging/audit_binary_package.py",
+    "packaging/audit_android_package.py",
     "packaging/macos/Info.plist",
     "patcher/Cargo.lock",
     "patcher/Cargo.toml",
@@ -56,6 +59,14 @@ REQUIRED = {
     "patcher/src/lib.rs",
     "patcher/src/main.rs",
     "patcher/src/recipe.rs",
+    "patcher/src/android.rs",
+    "android/README.md",
+    "android/app/build.gradle",
+    "android/app/src/main/AndroidManifest.xml",
+    "android/app/src/main/java/ai/smf/mariosmask/MainActivity.java",
+    "android/build.gradle",
+    "android/gradle.properties",
+    "android/settings.gradle",
     "site/README.md",
     "site/app.js",
     "site/index.html",


### PR DESCRIPTION
Adds the Android 8+ builder app, universal ARM64/x86-64 APK packaging, release signing and audits, permanent tag automation, and the v0.9.0 APK backfill workflow. The app uses Android document pickers and the same Rust patch engine as desktop; no ROMs are bundled.