### PR TITLE
Enforce the Android 8 API floor

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -59,7 +59,7 @@ jobs:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
-          gradle -p android --no-daemon :app:assembleRelease
+          gradle -p android --no-daemon :app:lintRelease :app:assembleRelease
           cp android/app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
           python3 packaging/audit_android_package.py "$RUNNER_TEMP/MariosMaskBuilder-android.apk"
           "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$RUNNER_TEMP/MariosMaskBuilder-android.apk"

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -53,7 +53,7 @@ jobs:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
-          gradle -p android --no-daemon :app:assembleRelease
+          gradle -p android --no-daemon :app:lintRelease :app:assembleRelease
           mkdir -p "$RUNNER_TEMP/release"
           cp android/app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"
           python3 packaging/audit_android_package.py "$RUNNER_TEMP/release/MariosMaskBuilder-android.apk"

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -34,7 +34,7 @@ jobs:
             --no-default-features --features android-jni
       - name: Build and audit debug-signed APK
         run: |
-          gradle -p android --no-daemon :app:assembleDebug
+          gradle -p android --no-daemon :app:lintDebug :app:assembleDebug
           python3 packaging/audit_android_package.py android/app/build/outputs/apk/debug/app-debug.apk
           "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose android/app/build/outputs/apk/debug/app-debug.apk
 

--- a/android/README.md
+++ b/android/README.md
@@ -19,7 +19,7 @@ cargo ndk -t arm64-v8a -t x86_64 \
   -o ../android/app/src/main/jniLibs \
   build --release --locked --no-default-features --features android-jni
 cd ..
-gradle -p android :app:assembleDebug
+gradle -p android :app:lintDebug :app:assembleDebug
 ```
 
 Release builds require the four `ANDROID_KEY*`/`ANDROID_KEYSTORE*` environment

--- a/android/app/src/main/java/ai/smf/mariosmask/MainActivity.java
+++ b/android/app/src/main/java/ai/smf/mariosmask/MainActivity.java
@@ -254,7 +254,7 @@ public final class MainActivity extends Activity {
                 });
             } catch (Exception error) {
                 String message = error.getMessage();
-                if (message == null || message.isBlank()) {
+                if (message == null || message.trim().isEmpty()) {
                     message = error.getClass().getSimpleName();
                 }
                 String finalMessage = message;
@@ -313,7 +313,7 @@ public final class MainActivity extends Activity {
     }
 
     private static Uri parseUri(String value) {
-        return value == null || value.isBlank() ? null : Uri.parse(value);
+        return value == null || value.trim().isEmpty() ? null : Uri.parse(value);
     }
 
     private static void deleteRecursively(File path) {


### PR DESCRIPTION
Replaces Java APIs newer than the declared Android 8 minimum and makes Android lint a required debug, release, and tag-package gate.