### PR TITLE
Fix browser patcher audit mode

### DIFF
--- a/.github/workflows/project-pages.yml
+++ b/.github/workflows/project-pages.yml
@@ -39,7 +39,7 @@ jobs:
           cargo build --manifest-path patcher/Cargo.toml --target wasm32-unknown-unknown --release --no-default-features --features web
           wasm-bindgen patcher/target/wasm32-unknown-unknown/release/marios_mask_builder.wasm --target web --out-dir site/pkg --no-typescript
       - name: Validate project site
-        run: python3 tools/check_project_site.py
+        run: python3 tools/check_project_site.py --require-built-patcher
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -51,7 +51,7 @@ jobs:
         run: python3 tools/release_audit.py --tree .
       - name: Check coupled release pins
         run: python3 tools/check_release_contract.py
-      - name: Check undeployed project splash page
+      - name: Check project site source
         run: python3 tools/check_project_site.py
       - name: Test and size-check the standalone patcher
         run: |

--- a/tools/check_project_site.py
+++ b/tools/check_project_site.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 from pathlib import Path
@@ -24,7 +25,7 @@ def require(condition: bool, message: str) -> None:
         raise SystemExit(f"project site: FAIL: {message}")
 
 
-def main() -> int:
+def main(require_built_patcher: bool = False) -> int:
     stable = json.loads((SITE / "stable.json").read_text(encoding="utf-8"))
     html = (SITE / "index.html").read_text(encoding="utf-8")
     patcher_script = (SITE / "patcher.js").read_text(encoding="utf-8")
@@ -55,11 +56,24 @@ def main() -> int:
     require('fetch("stable.json")' in patcher_script, "patcher may only fetch local release metadata")
     require("fetch(" not in worker_script, "ROM worker must make no network requests")
     require('./pkg/marios_mask_builder.js' in worker_script, "worker must load the local WASM patcher")
-    require((SITE / "pkg" / "marios_mask_builder.js").is_file(), "generated WASM loader is missing")
-    require((SITE / "pkg" / "marios_mask_builder_bg.wasm").is_file(), "generated WASM binary is missing")
-    print(f"project site: PASS (stable v{stable['version']}, minimal local patcher, Pages-ready)")
+    loader_exists = (SITE / "pkg" / "marios_mask_builder.js").is_file()
+    wasm_exists = (SITE / "pkg" / "marios_mask_builder_bg.wasm").is_file()
+    require(loader_exists == wasm_exists, "generated browser patcher is incomplete")
+    if require_built_patcher:
+        require(loader_exists, "generated WASM loader is missing")
+        require(wasm_exists, "generated WASM binary is missing")
+
+    mode = "built" if require_built_patcher else "source"
+    print(f"project site: PASS (stable v{stable['version']}, minimal local patcher, {mode} check)")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--require-built-patcher",
+        action="store_true",
+        help="require the generated JavaScript loader and WebAssembly binary",
+    )
+    arguments = parser.parse_args()
+    raise SystemExit(main(arguments.require_built_patcher))


### PR DESCRIPTION
Fixes the recurring standalone-release failure by separating clean-checkout source validation from post-build WebAssembly artifact validation. Pages still requires and verifies the generated WASM files.