### PR TITLE
Use a unified unboxed patcher layout

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -2,8 +2,6 @@
   color-scheme: dark;
   --ink: #f8f3e8;
   --muted: #c9bdac;
-  --surface: #221a14;
-  --line: rgba(255, 255, 255, 0.14);
   --gold: #f4c95d;
   --green: #3e8e55;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
@@ -36,7 +34,6 @@ main {
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
-  border-radius: 18px;
 }
 
 h1 {
@@ -48,18 +45,11 @@ h1 {
   text-align: center;
 }
 
-.patcher {
-  padding: 28px;
-  border: 1px solid var(--line);
-  border-radius: 18px;
-  background: var(--surface);
-}
-
 .rom-inputs,
 .colour-options {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+  gap: 28px;
 }
 
 .rom-input,
@@ -68,21 +58,18 @@ h1 {
   display: flex;
   gap: 12px;
   align-items: center;
-  padding: 16px;
+  padding: 0;
   cursor: pointer;
-  border: 1px solid var(--line);
-  border-radius: 12px;
 }
 
 .rom-input {
-  min-height: 116px;
   align-items: flex-start;
 }
 
-.rom-input:hover,
-.rom-input:focus-within,
-.colour-option:has(input[type="radio"]:checked) {
-  border-color: var(--gold);
+.rom-input:hover .file-name,
+.rom-input:focus-within .file-name,
+.colour-option:has(input[type="radio"]:checked) strong {
+  color: var(--gold);
 }
 
 .rom-input input {
@@ -182,6 +169,10 @@ small {
   margin-top: 24px;
 }
 
+.build-actions:has(.download-button[hidden]) {
+  grid-template-columns: 1fr;
+}
+
 .build-button,
 .download-button {
   display: flex;
@@ -230,10 +221,6 @@ small {
 
   h1 {
     margin: 28px 0;
-  }
-
-  .patcher {
-    padding: 18px;
   }
 
   .rom-inputs,

--- a/tools/check_project_site.py
+++ b/tools/check_project_site.py
@@ -28,6 +28,7 @@ def require(condition: bool, message: str) -> None:
 def main(require_built_patcher: bool = False) -> int:
     stable = json.loads((SITE / "stable.json").read_text(encoding="utf-8"))
     html = (SITE / "index.html").read_text(encoding="utf-8")
+    styles = (SITE / "styles.css").read_text(encoding="utf-8")
     patcher_script = (SITE / "patcher.js").read_text(encoding="utf-8")
     worker_script = (SITE / "patcher-worker.js").read_text(encoding="utf-8")
 
@@ -46,6 +47,8 @@ def main(require_built_patcher: bool = False) -> int:
     require(html.count('type="file"') == 3, "browser patcher must request exactly three ROMs")
     require(html.count('name="mario-colour"') == 3, "all Mario colour options must remain")
     require("build-rom" in html and "download-rom" in html, "build and download controls must remain")
+    require("background: var(--surface)" not in styles, "patcher must not use a card background")
+    require("border: 1px solid var(--line)" not in styles, "options must not use card borders")
     require("Content-Security-Policy" in html, "missing content security policy")
     require("script-src 'self'" in html, "scripts must be restricted to this site")
     require("connect-src 'self'" in html, "network connections must be restricted to this site")


### PR DESCRIPTION
Removes the patcher container, ROM tile, colour-option, and hero corner box treatments. Controls now sit directly in one continuous page; only build and download remain button-shaped.