### PR TITLE
Deploy Pages from the exact release HTML

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -173,6 +175,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [android-package, posix-packages, windows-package, web-package]
     runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -187,3 +192,17 @@ jobs:
           gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
             gh release create "$GITHUB_REF_NAME" --prerelease --title "Mario's Mask Alpha ${GITHUB_REF_NAME#v}" --notes-file RELEASE_NOTES.md
           gh release upload "$GITHUB_REF_NAME" release-assets/* --clobber
+      - name: Stage the exact release HTML for Pages
+        run: |
+          mkdir pages
+          cp release-assets/MariosMaskBuilder-web.html pages/index.html
+          cp release-assets/MariosMaskBuilder-web.html pages/MariosMaskBuilder-web.html
+          cmp release-assets/MariosMaskBuilder-web.html pages/index.html
+          cmp release-assets/MariosMaskBuilder-web.html pages/MariosMaskBuilder-web.html
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages
+      - name: Deploy exact release HTML to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/project-pages.yml
+++ b/.github/workflows/project-pages.yml
@@ -1,6 +1,13 @@
 name: project-pages
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/project-pages.yml
+      - patcher/**
+      - site/**
+      - tools/build_web_release.py
+      - tools/check_project_site.py
   push:
     branches: [main]
     paths:
@@ -13,18 +20,13 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: github-pages
+  group: project-pages-validation-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  validate:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -42,11 +44,4 @@ jobs:
       - name: Validate project site
         run: |
           python3 tools/check_project_site.py --require-built-patcher
-          python3 tools/build_web_release.py --output site/MariosMaskBuilder-web.html
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          python3 tools/build_web_release.py --output "$RUNNER_TEMP/MariosMaskBuilder-web.html"


### PR DESCRIPTION
Makes each tag workflow deploy the same MariosMaskBuilder-web.html bytes to GitHub Pages and to release assets. Main and PR pushes now validate only, so unreleased main changes cannot replace the latest released patcher.