### PR TITLE
Keep Ocarina revisions out of builder blurb

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -25,7 +25,6 @@
       <section class="patcher" aria-label="Mario's Mask patcher options">
         <p class="rom-requirements">
           <strong>Use NTSC Nintendo 64 ROMs for all three games.</strong>
-          Ocarina of Time may be revision 1.0, 1.1, or 1.2.
         </p>
         <div class="rom-inputs">
           <label class="rom-input" for="sm64-rom">

--- a/tools/check_project_site.py
+++ b/tools/check_project_site.py
@@ -51,8 +51,12 @@ def main(require_built_patcher: bool = False) -> int:
         "browser patcher must clearly require NTSC ROMs",
     )
     require(
-        "Ocarina of Time may be revision 1.0, 1.1, or 1.2." in html,
-        "browser patcher must list supported Ocarina of Time revisions",
+        "NTSC ROM — revision 1.0, 1.1, or 1.2" in html,
+        "Ocarina ROM input must list supported revisions",
+    )
+    require(
+        "Ocarina of Time may be revision 1.0, 1.1, or 1.2." not in html,
+        "supported Ocarina revisions belong on its ROM input, not in the blurb",
     )
     require(html.count('name="mario-colour"') == 3, "all Mario colour options must remain")
     require("build-rom" in html and "download-rom" in html, "build and download controls must remain")


### PR DESCRIPTION
Moves the supported Ocarina revision detail out of the top builder blurb while retaining it beside the Ocarina ROM selector. Updates the site regression check accordingly.\n\nNo release is created.