### PR TITLE
Add first speedrun leaderboard entry

### DIFF
--- a/site/speedruns.html
+++ b/site/speedruns.html
@@ -17,6 +17,10 @@
     <main class="leaderboard-page">
       <p class="back-link"><a href="index.html">← Mario's Mask builder</a></p>
       <h1>Speedrun Leaderboard</h1>
+      <p class="speedrun-rule">
+        Runs on newer versions always rank above runs on older versions. Within
+        the same version, the fastest time ranks first.
+      </p>
       <table class="speedrun-table">
         <thead>
           <tr>

--- a/site/speedruns.js
+++ b/site/speedruns.js
@@ -8,13 +8,33 @@ function addCell(row, value) {
   row.append(cell);
 }
 
+function compareVersionsDescending(left, right) {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (rightParts[index] || 0) - (leftParts[index] || 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function timeInSeconds(time) {
+  return time.split(":").reduce((total, part) => total * 60 + Number(part), 0);
+}
+
+function compareRuns(left, right) {
+  return compareVersionsDescending(left.version, right.version)
+    || timeInSeconds(left.time) - timeInSeconds(right.time);
+}
+
 try {
   const response = await fetch("speedruns.json");
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const runs = await response.json();
   if (!Array.isArray(runs)) throw new Error("the leaderboard data is not a list");
 
-  for (const run of runs) {
+  for (const run of [...runs].sort(compareRuns)) {
     const row = document.createElement("tr");
     addCell(row, run.username);
     addCell(row, run.time);

--- a/site/speedruns.json
+++ b/site/speedruns.json
@@ -1,1 +1,7 @@
-[]
+[
+  {
+    "username": "rubbertoe64",
+    "time": "2:10:24.27",
+    "version": "0.11.5"
+  }
+]

--- a/site/styles.css
+++ b/site/styles.css
@@ -552,6 +552,11 @@ dialog p {
   margin: 0 0 28px;
 }
 
+.speedrun-rule {
+  margin: -18px 0 28px;
+  color: var(--muted);
+}
+
 .speedrun-table {
   width: 100%;
   border-collapse: collapse;

--- a/tools/check_project_site.py
+++ b/tools/check_project_site.py
@@ -113,9 +113,17 @@ def main(require_built_patcher: bool = False) -> int:
             isinstance(run, dict)
             and set(run) == {"username", "time", "version"}
             and all(isinstance(value, str) and value.strip() for value in run.values())
+            and re.fullmatch(r"\d+:\d{2}:\d{2}(?:\.\d+)?", run["time"]) is not None
+            and re.fullmatch(r"\d+\.\d+\.\d+", run["version"]) is not None
             for run in speedruns
         ),
-        "every speedrun must have a non-empty username, time and version",
+        "every speedrun must have a username and valid time/version",
+    )
+    require(
+        "newer versions always rank above" in speedruns_html
+        and "compareVersionsDescending" in speedruns_script
+        and "timeInSeconds(left.time) - timeInSeconds(right.time)" in speedruns_script,
+        "leaderboard must rank newer versions first and then faster times",
     )
     require(
         'fetch("speedruns.json")' in speedruns_script and "textContent = value" in speedruns_script,


### PR DESCRIPTION
Adds rubbertoe64's 2:10:24.27 run on Alpha 0.11.5. The leaderboard now enforces the ranking rule that newer-version runs always rank above older-version runs, with time breaking order within a version.\n\nValidated by the built project-site check and public-history release audit.