### PR TITLE
Fix speedrun leaderboard rendering

### DIFF
--- a/site/speedruns.js
+++ b/site/speedruns.js
@@ -28,20 +28,24 @@ function compareRuns(left, right) {
     || timeInSeconds(left.time) - timeInSeconds(right.time);
 }
 
-try {
-  const response = await fetch("speedruns.json");
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const runs = await response.json();
-  if (!Array.isArray(runs)) throw new Error("the leaderboard data is not a list");
+async function loadSpeedruns() {
+  try {
+    const response = await fetch("speedruns.json");
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const runs = await response.json();
+    if (!Array.isArray(runs)) throw new Error("the leaderboard data is not a list");
 
-  for (const run of [...runs].sort(compareRuns)) {
-    const row = document.createElement("tr");
-    addCell(row, run.username);
-    addCell(row, run.time);
-    addCell(row, run.version);
-    results.append(row);
+    for (const run of [...runs].sort(compareRuns)) {
+      const row = document.createElement("tr");
+      addCell(row, run.username);
+      addCell(row, run.time);
+      addCell(row, run.version);
+      results.append(row);
+    }
+    empty.hidden = runs.length !== 0;
+  } catch (error) {
+    status.textContent = `The leaderboard could not be loaded: ${error.message}`;
   }
-  empty.hidden = runs.length !== 0;
-} catch (error) {
-  status.textContent = `The leaderboard could not be loaded: ${error.message}`;
 }
+
+loadSpeedruns();


### PR DESCRIPTION
Loads the leaderboard through an async function instead of invalid top-level await in a classic deferred script. This restores the published rubbertoe64 entry in Safari and other classic-script browsers.