### PR TITLE
Remove outdated Clock Town screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ included for convenience—you can still play the introduction whenever you want
 
 ## Move through Termina like Mario
 
-![Mario running through Clock Town](https://github.com/msmfai/marios-mask/releases/download/v0.8.0/clock-town.png)
-
 Mario can run, punch, kick, crouch, crawl, swim, climb ledges, long-jump,
 side-flip, triple-jump, wall-jump, and ground-pound. His momentum, aerial
 control, rebounds, falls, voice, and animation make familiar places feel new and

--- a/site/README.md
+++ b/site/README.md
@@ -50,5 +50,7 @@ The remaining legacy screenshots to replace are:
 
 - the mysterious stone door wobbling;
 - the area beyond the door in Peach's Castle;
-- Mario traversing Clock Town;
 - Mario reacting to Dinolfos fire breath.
+
+The outdated Clock Town traversal image has been removed from the public README;
+that section still needs a fresh current-build screenshot.


### PR DESCRIPTION
Removes the unmatched legacy Clock Town screenshot rather than leaving an outdated Mario appearance live or substituting an unrelated frame. Records that the slot still needs a fresh current-build capture.\n\nLocal checks: release_audit PASS; project site PASS; git diff --check PASS.